### PR TITLE
make CMake happy if this project is used as a subproject of others

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,4 +48,11 @@ add_library(
         src/operations/string/substr.cpp
 )
 
+target_include_directories(
+  ${PROJECT_NAME}
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src/>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/lib/json/include/nlohmann/>
+)
+
 add_subdirectory(test)


### PR DESCRIPTION
It is now easy to include project from other CMakeLists.txt as such
```
FetchContent_Declare(jsonlogic
  GIT_REPOSITORY https://github.com/tonuonu/json-logic-cpp
  GIT_TAG main
)
FetchContent_MakeAvailable(jsonlogic)
```
and add includes without need to point to include directories of this library. 