### PR TITLE
remove implicit casts, add constness and minor clean ups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,6 @@ target_include_directories(
   ${PROJECT_NAME}
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src/>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/lib/json/include/nlohmann/>
 )
 
 add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.18)
 project(jsonlogic VERSION 0.1 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 include_directories(src)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,9 @@ add_library(
         src/operations/string/substr.cpp
 )
 
+# Enable warnings as errors for the library
+target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Werror)
+
 find_package(nlohmann_json 3.9.1 REQUIRED)
 
 target_link_libraries(${PROJECT_NAME} PRIVATE nlohmann_json::nlohmann_json)

--- a/src/json_logic.cpp
+++ b/src/json_logic.cpp
@@ -63,7 +63,7 @@ namespace json_logic
 		return singleton_;
 	}
 
-	json JsonLogic::Apply(const json& logic, const json& data) // NOLINT(google-default-arguments)
+	json JsonLogic::Apply(const json& logic, const json& data) const // NOLINT(google-default-arguments)
 	{
 		if (logic.is_array())
 		{

--- a/src/json_logic.cpp
+++ b/src/json_logic.cpp
@@ -139,7 +139,7 @@ namespace json_logic
 
 	bool JsonLogic::Truthy(const json& value)
 	{
-		if (value.is_boolean()) return value;
+		if (value.is_boolean()) return value.get<bool>();
 
 		if (value.is_number() && value != 0) return true;
 		if (value.is_array() && !value.empty()) return true;

--- a/src/json_logic.h
+++ b/src/json_logic.h
@@ -19,7 +19,7 @@ namespace json_logic
     {
     public:
         virtual ~IJsonLogic() = default;
-        virtual json Apply(const json& logic, const json& data = json::object()) = 0; // NOLINT(google-default-arguments)
+        virtual json Apply(const json& logic, const json& data = json::object()) const = 0; // NOLINT(google-default-arguments)
     };
 
 	class JsonLogic : public IJsonLogic
@@ -31,7 +31,7 @@ namespace json_logic
 
 		static JsonLogic *GetInstance();
 
-		json Apply(const json& logic, const json& data = json::object()) override; // NOLINT(google-default-arguments)
+		json Apply(const json& logic, const json& data = json::object()) const override; // NOLINT(google-default-arguments)
 		[[maybe_unused]] void AddOperation(const std::string& name, const Operation& operation);
 		[[maybe_unused]] void RmOperation(const std::string& name);
 
@@ -47,46 +47,46 @@ namespace json_logic
 	private:
         std::unordered_map<std::string, Operation> operations_;
 
-		json operation_data_var(const json& values, const json& data);
-		json operation_data_missing(const json& values, const json& data);
-		json operation_data_missing_some(const json& values, const json& data);
+		json operation_data_var(const json& values, const json& data) const;
+		json operation_data_missing(const json& values, const json& data) const;
+		json operation_data_missing_some(const json& values, const json& data) const;
 
-		json operation_logic_if(const json& values, const json& data);
-		json operation_logic_abstract_equal(const json& values, const json& data);
-		json operation_logic_strict_equal(const json& values, const json& data);
-		json operation_logic_abstract_different(const json& values, const json& data);
-		json operation_logic_strict_different(const json& values, const json& data);
-		json operation_logic_not(const json& values, const json& data);
-		json operation_logic_truthy(const json& values, const json& data);
-		json operation_logic_or(const json& values, const json& data);
-		json operation_logic_and(const json& values, const json& data);
+		json operation_logic_if(const json& values, const json& data) const;
+		json operation_logic_abstract_equal(const json& values, const json& data) const;
+		json operation_logic_strict_equal(const json& values, const json& data) const;
+		json operation_logic_abstract_different(const json& values, const json& data) const;
+		json operation_logic_strict_different(const json& values, const json& data) const;
+		json operation_logic_not(const json& values, const json& data) const;
+		json operation_logic_truthy(const json& values, const json& data) const;
+		json operation_logic_or(const json& values, const json& data) const;
+		json operation_logic_and(const json& values, const json& data) const;
 
-		json operation_numeric_gt(const json& values, const json& data);
-		json operation_numeric_gte(const json& values, const json& data);
-		json operation_numeric_lt(const json& values, const json& data);
-		json operation_numeric_lte(const json& values, const json& data);
-		json operation_numeric_max(const json& values, const json& data);
-		json operation_numeric_min(const json& values, const json& data);
-		json operation_numeric_addition(const json& values, const json& data);
-		json operation_numeric_subtraction(const json& values, const json& data);
-		json operation_numeric_multiplication(const json& values, const json& data);
-		json operation_numeric_division(const json& values, const json& data);
-		json operation_numeric_modulo(const json& values, const json& data);
+		json operation_numeric_gt(const json& values, const json& data) const;
+		json operation_numeric_gte(const json& values, const json& data) const;
+		json operation_numeric_lt(const json& values, const json& data) const;
+		json operation_numeric_lte(const json& values, const json& data) const;
+		json operation_numeric_max(const json& values, const json& data) const;
+		json operation_numeric_min(const json& values, const json& data) const;
+		json operation_numeric_addition(const json& values, const json& data) const;
+		json operation_numeric_subtraction(const json& values, const json& data) const;
+		json operation_numeric_multiplication(const json& values, const json& data) const;
+		json operation_numeric_division(const json& values, const json& data) const;
+		json operation_numeric_modulo(const json& values, const json& data) const;
 
-		json operation_array_map(const json& values, const json& data);
-		json operation_array_reduce(const json& values, const json& data);
-		json operation_array_filter(const json& values, const json& data);
-		json operation_array_all(const json& values, const json& data);
-		json operation_array_none(const json& values, const json& data);
-		json operation_array_some(const json& values, const json& data);
-		json operation_array_merge(const json& values, const json& data);
+		json operation_array_map(const json& values, const json& data) const;
+		json operation_array_reduce(const json& values, const json& data) const;
+		json operation_array_filter(const json& values, const json& data) const;
+		json operation_array_all(const json& values, const json& data) const;
+		json operation_array_none(const json& values, const json& data) const;
+		json operation_array_some(const json& values, const json& data) const;
+		json operation_array_merge(const json& values, const json& data) const;
 
-		json operation_array_string_in(const json& values, const json& data);
+		json operation_array_string_in(const json& values, const json& data) const;
 
-		json operation_string_cat(const json& values, const json& data);
-		json operation_string_substr(const json& values, const json& data);
+		json operation_string_cat(const json& values, const json& data) const;
+		json operation_string_substr(const json& values, const json& data) const;
 
-		json operation_misc_log(const json& values, const json& data);
+		json operation_misc_log(const json& values, const json& data) const;
 
 		static bool Truthy(const json& value);
 	};

--- a/src/json_logic.h
+++ b/src/json_logic.h
@@ -18,6 +18,7 @@ namespace json_logic
     class IJsonLogic
     {
     public:
+        virtual ~IJsonLogic() = default;
         virtual json Apply(const json& logic, const json& data = json::object()) = 0; // NOLINT(google-default-arguments)
     };
 

--- a/src/operations/array/all.cpp
+++ b/src/operations/array/all.cpp
@@ -8,7 +8,7 @@ using namespace nlohmann;
 
 namespace json_logic
 {
-    json JsonLogic::operation_array_all(const json& values, const json& data)
+    json JsonLogic::operation_array_all(const json& values, const json& data) const
     {
 		if (values.size() != 2)
 			throw JsonLogicException(

--- a/src/operations/array/all.cpp
+++ b/src/operations/array/all.cpp
@@ -23,7 +23,7 @@ namespace json_logic
 			throw JsonLogicException(__FUNCTION__, "First argument must be an array");
 
 		if (!IsLogic(logic))
-			throw JsonLogicException(__FUNCTION__, "Secong argument must be a logic object");
+			throw JsonLogicException(__FUNCTION__, "Second argument must be a logic object");
 
         return std::all_of(
             array.begin(),

--- a/src/operations/array/filter.cpp
+++ b/src/operations/array/filter.cpp
@@ -8,7 +8,7 @@ using namespace nlohmann;
 
 namespace json_logic
 {
-    json JsonLogic::operation_array_filter(const json& values, const json& data)
+    json JsonLogic::operation_array_filter(const json& values, const json& data) const
     {
 		if (values.size() != 2)
 			throw JsonLogicException(

--- a/src/operations/array/in.cpp
+++ b/src/operations/array/in.cpp
@@ -9,7 +9,7 @@ using namespace nlohmann;
 
 namespace json_logic
 {
-    json JsonLogic::operation_array_string_in(const json& values, const json& data)
+    json JsonLogic::operation_array_string_in(const json& values, const json& data) const
     {
 		if (values.size() != 2)
 			throw JsonLogicException(

--- a/src/operations/array/map.cpp
+++ b/src/operations/array/map.cpp
@@ -23,7 +23,7 @@ namespace json_logic
 			throw JsonLogicException(__FUNCTION__, "First argument must be an array");
 
         if (!IsLogic(logic))
-			throw JsonLogicException(__FUNCTION__, "Secong argument must be a logic object");
+			throw JsonLogicException(__FUNCTION__, "Second argument must be a logic object");
 
 		auto result = json::array();
 

--- a/src/operations/array/map.cpp
+++ b/src/operations/array/map.cpp
@@ -8,7 +8,7 @@ using namespace nlohmann;
 
 namespace json_logic
 {
-    json JsonLogic::operation_array_map(const json& values, const json& data)
+    json JsonLogic::operation_array_map(const json& values, const json& data) const
     {
 		if (values.size() != 2)
 			throw JsonLogicException(

--- a/src/operations/array/merge.cpp
+++ b/src/operations/array/merge.cpp
@@ -8,7 +8,7 @@ using namespace nlohmann;
 
 namespace json_logic
 {
-    json JsonLogic::operation_array_merge(const json& values, const json& data)
+    json JsonLogic::operation_array_merge(const json& values, const json& data) const
     {
         if (values.empty()) return json::array();
 

--- a/src/operations/array/none.cpp
+++ b/src/operations/array/none.cpp
@@ -6,8 +6,8 @@ using namespace nlohmann;
 
 namespace json_logic
 {
-    json JsonLogic::operation_array_none(const json& values, const json& data)
+    json JsonLogic::operation_array_none(const json& values, const json& data) const
     {
-        return !operations_["some"](values, data);
+        return !operations_.at("some")(values, data);
     }
 }

--- a/src/operations/array/reduce.cpp
+++ b/src/operations/array/reduce.cpp
@@ -9,7 +9,7 @@ using namespace nlohmann;
 
 namespace json_logic
 {
-    json JsonLogic::operation_array_reduce(const json& values, const json& data)
+    json JsonLogic::operation_array_reduce(const json& values, const json& data) const
     {
 		if (values.size() != 3)
 			throw JsonLogicException(

--- a/src/operations/array/some.cpp
+++ b/src/operations/array/some.cpp
@@ -8,7 +8,7 @@ using namespace nlohmann;
 
 namespace json_logic
 {
-    json JsonLogic::operation_array_some(const json& values, const json& data)
+    json JsonLogic::operation_array_some(const json& values, const json& data) const
     {
 		if (values.size() != 2)
 			throw JsonLogicException(

--- a/src/operations/array/some.cpp
+++ b/src/operations/array/some.cpp
@@ -23,7 +23,7 @@ namespace json_logic
 			throw JsonLogicException(__FUNCTION__, "First argument must be an array");
 
 		if (!IsLogic(logic))
-			throw JsonLogicException(__FUNCTION__, "Secong argument must be a logic object");
+			throw JsonLogicException(__FUNCTION__, "Second argument must be a logic object");
 
         return std::any_of(
             array.begin(),

--- a/src/operations/data/missing.cpp
+++ b/src/operations/data/missing.cpp
@@ -9,7 +9,7 @@ using namespace nlohmann;
 
 namespace json_logic
 {
-    json JsonLogic::operation_data_missing(const json& values, const json& data)
+    json JsonLogic::operation_data_missing(const json& values, const json& data) const
     {
 		if (values.empty())
 			throw JsonLogicException(

--- a/src/operations/data/missing_some.cpp
+++ b/src/operations/data/missing_some.cpp
@@ -9,7 +9,7 @@ using namespace nlohmann;
 
 namespace json_logic
 {
-    json JsonLogic::operation_data_missing_some(const json& values, const json& data)
+    json JsonLogic::operation_data_missing_some(const json& values, const json& data) const
     {
         if (values.size() != 2)
             throw JsonLogicException(

--- a/src/operations/data/var.cpp
+++ b/src/operations/data/var.cpp
@@ -44,7 +44,7 @@ namespace json_logic
                     if (!current.is_array())
                         throw JsonLogicException(__FUNCTION__, "Data object is not an array, but index was provided");
 
-                    if (index >= current.size())
+                    if (static_cast<std::size_t>(index) >= current.size())
                         throw JsonLogicException(__FUNCTION__, "Array index out of bounds");
 
                     current = current[index];

--- a/src/operations/data/var.cpp
+++ b/src/operations/data/var.cpp
@@ -11,7 +11,7 @@ using namespace nlohmann;
 
 namespace json_logic
 {
-    json JsonLogic::operation_data_var(const json& values, const json& data) // NOLINT(readability-convert-member-functions-to-static)
+    json JsonLogic::operation_data_var(const json& values, const json& data) const // NOLINT(readability-convert-member-functions-to-static)
     {
         json current = data;
 

--- a/src/operations/logic/and.cpp
+++ b/src/operations/logic/and.cpp
@@ -8,7 +8,7 @@ using namespace nlohmann;
 
 namespace json_logic
 {
-    json JsonLogic::operation_logic_and(const json& values, const json& data)
+    json JsonLogic::operation_logic_and(const json& values, const json& data) const
     {
         return std::all_of(
             values.begin(),

--- a/src/operations/logic/different.cpp
+++ b/src/operations/logic/different.cpp
@@ -6,7 +6,7 @@ using namespace nlohmann;
 
 namespace json_logic
 {
-    json JsonLogic::operation_logic_strict_different(const json& values, const json& data)
+    json JsonLogic::operation_logic_strict_different(const json& values, const json& data) const
     {
         if (values.size() != 2)
             throw JsonLogicException(
@@ -14,10 +14,10 @@ namespace json_logic
                 "Expected 2 arguments, but received " + std::to_string(values.size())
             );
 
-        return !operations_["==="](values, data);
+        return !operations_.at("===")(values, data);
     }
 
-    json JsonLogic::operation_logic_abstract_different(const json& values, const json& data)
+    json JsonLogic::operation_logic_abstract_different(const json& values, const json& data) const
     {
         if (values.size() != 2)
             throw JsonLogicException(
@@ -25,6 +25,6 @@ namespace json_logic
                 "Expected 2 arguments, but received " + std::to_string(values.size())
             );
 
-        return !operations_["=="](values, data);
+        return !operations_.at("==")(values, data);
     }
 }

--- a/src/operations/logic/equal.cpp
+++ b/src/operations/logic/equal.cpp
@@ -15,7 +15,7 @@ namespace json_logic
 	static bool double_equal(double lhs, double rhs);
 	static bool directional_abstract_equal(const json& lhs, const json& rhs);
 
-    json JsonLogic::operation_logic_strict_equal(const json& values, const json& data)
+    json JsonLogic::operation_logic_strict_equal(const json& values, const json& data) const
     {
         if (values.size() != 2)
             throw JsonLogicException(
@@ -29,7 +29,7 @@ namespace json_logic
         return strict_equal(a, b);
     }
 
-    json JsonLogic::operation_logic_abstract_equal(const json& values, const json& data)
+    json JsonLogic::operation_logic_abstract_equal(const json& values, const json& data) const
     {
         if (values.size() != 2)
             throw JsonLogicException(

--- a/src/operations/logic/equal.cpp
+++ b/src/operations/logic/equal.cpp
@@ -72,7 +72,7 @@ namespace json_logic
 		if (lhs == 1 && rhs == true) return true;
 
 		// 42 == "42.0" -> true
-		if (rhs.is_string() && double_equal(lhs, std::stod(rhs.get<std::string>()))) return true;
+		if (rhs.is_string() && double_equal(lhs.get<double>(), std::stod(rhs.get<std::string>()))) return true;
 
 		// 0 == [] -> true
 		if (rhs.is_array() && rhs.empty() && lhs == 0) return true;

--- a/src/operations/logic/if.cpp
+++ b/src/operations/logic/if.cpp
@@ -6,7 +6,7 @@ using namespace nlohmann;
 
 namespace json_logic
 {
-    json JsonLogic::operation_logic_if(const json& values, const json& data)
+    json JsonLogic::operation_logic_if(const json& values, const json& data) const
     {
         if (values.size() < 3 || values.size() % 2 == 0)
             throw JsonLogicException(

--- a/src/operations/logic/not.cpp
+++ b/src/operations/logic/not.cpp
@@ -6,7 +6,7 @@ using namespace nlohmann;
 
 namespace json_logic
 {
-    json JsonLogic::operation_logic_not(const json& values, const json& data)
+    json JsonLogic::operation_logic_not(const json& values, const json& data) const
     {
 		if (values.size() != 1)
 			throw JsonLogicException(
@@ -14,6 +14,6 @@ namespace json_logic
 				"Expected 1 argument, but received " + std::to_string(values.size())
 			);
 
-		return !operations_["!!"](values, data);
+		return !operations_.at("!!")(values, data);
     }
 }

--- a/src/operations/logic/or.cpp
+++ b/src/operations/logic/or.cpp
@@ -8,7 +8,7 @@ using namespace nlohmann;
 
 namespace json_logic
 {
-    json JsonLogic::operation_logic_or(const json& values, const json& data)
+    json JsonLogic::operation_logic_or(const json& values, const json& data) const
     {
         return std::any_of(
             values.begin(),

--- a/src/operations/logic/truthy.cpp
+++ b/src/operations/logic/truthy.cpp
@@ -6,7 +6,7 @@ using namespace nlohmann;
 
 namespace json_logic
 {
-    json JsonLogic::operation_logic_truthy(const json& values, const json& data)
+    json JsonLogic::operation_logic_truthy(const json& values, const json& data) const
     {
 		if (values.size() != 1)
 			throw JsonLogicException(

--- a/src/operations/misc/log.cpp
+++ b/src/operations/misc/log.cpp
@@ -8,7 +8,7 @@ using namespace nlohmann;
 
 namespace json_logic
 {
-    json JsonLogic::operation_misc_log(const json& values, const json& data)
+    json JsonLogic::operation_misc_log(const json& values, const json& data) const
     {
 		if (values.size() != 1)
 			throw JsonLogicException(

--- a/src/operations/numeric/addition.cpp
+++ b/src/operations/numeric/addition.cpp
@@ -11,7 +11,7 @@ namespace json_logic
 {
     static json cast_to_number(const json& value);
 
-    json JsonLogic::operation_numeric_addition(const json& values, const json& data)
+    json JsonLogic::operation_numeric_addition(const json& values, const json& data) const
     {
 		if (values.empty())
 			throw JsonLogicException(

--- a/src/operations/numeric/division.cpp
+++ b/src/operations/numeric/division.cpp
@@ -8,7 +8,7 @@ using namespace nlohmann;
 
 namespace json_logic
 {
-    json JsonLogic::operation_numeric_division(const json& values, const json& data)
+    json JsonLogic::operation_numeric_division(const json& values, const json& data) const
     {
         if (values.size() != 2)
             throw JsonLogicException(

--- a/src/operations/numeric/gt.cpp
+++ b/src/operations/numeric/gt.cpp
@@ -6,7 +6,7 @@ using namespace nlohmann;
 
 namespace json_logic
 {
-    json JsonLogic::operation_numeric_gt(const json& values, const json& data)
+    json JsonLogic::operation_numeric_gt(const json& values, const json& data) const
     {
         if (values.size() != 2)
             throw JsonLogicException(

--- a/src/operations/numeric/gte.cpp
+++ b/src/operations/numeric/gte.cpp
@@ -6,7 +6,7 @@ using namespace nlohmann;
 
 namespace json_logic
 {
-    json JsonLogic::operation_numeric_gte(const json& values, const json& data)
+    json JsonLogic::operation_numeric_gte(const json& values, const json& data) const
     {
         if (values.size() != 2)
             throw JsonLogicException(

--- a/src/operations/numeric/lt.cpp
+++ b/src/operations/numeric/lt.cpp
@@ -6,7 +6,7 @@ using namespace nlohmann;
 
 namespace json_logic
 {
-    json JsonLogic::operation_numeric_lt(const json& values, const json& data)
+    json JsonLogic::operation_numeric_lt(const json& values, const json& data) const
     {
         if (values.size() < 2 || values.size() > 3)
             throw JsonLogicException(

--- a/src/operations/numeric/lte.cpp
+++ b/src/operations/numeric/lte.cpp
@@ -6,7 +6,7 @@ using namespace nlohmann;
 
 namespace json_logic
 {
-    json JsonLogic::operation_numeric_lte(const json& values, const json& data)
+    json JsonLogic::operation_numeric_lte(const json& values, const json& data) const
     {
         if (values.size() < 2 || values.size() > 3)
             throw JsonLogicException(

--- a/src/operations/numeric/max.cpp
+++ b/src/operations/numeric/max.cpp
@@ -6,7 +6,7 @@ using namespace nlohmann;
 
 namespace json_logic
 {
-    json JsonLogic::operation_numeric_max(const json& values, const json& data)
+    json JsonLogic::operation_numeric_max(const json& values, const json& data) const
     {
         if (values.empty())
             throw JsonLogicException(__FUNCTION__, "Expected at least 1 argument");

--- a/src/operations/numeric/min.cpp
+++ b/src/operations/numeric/min.cpp
@@ -6,7 +6,7 @@ using namespace nlohmann;
 
 namespace json_logic
 {
-    json JsonLogic::operation_numeric_min(const json& values, const json& data)
+    json JsonLogic::operation_numeric_min(const json& values, const json& data) const
     {
         if (values.empty())
             throw JsonLogicException(__FUNCTION__, "Expected at least 1 argument");

--- a/src/operations/numeric/modulo.cpp
+++ b/src/operations/numeric/modulo.cpp
@@ -6,7 +6,7 @@ using namespace nlohmann;
 
 namespace json_logic
 {
-    json JsonLogic::operation_numeric_modulo(const json& values, const json& data)
+    json JsonLogic::operation_numeric_modulo(const json& values, const json& data) const
     {
         if (values.size() != 2)
             throw JsonLogicException(

--- a/src/operations/numeric/multiplication.cpp
+++ b/src/operations/numeric/multiplication.cpp
@@ -6,7 +6,7 @@ using namespace nlohmann;
 
 namespace json_logic
 {
-    json JsonLogic::operation_numeric_multiplication(const json& values, const json& data)
+    json JsonLogic::operation_numeric_multiplication(const json& values, const json& data) const
     {
         if (values.size() < 2)
             throw JsonLogicException(

--- a/src/operations/numeric/subtraction.cpp
+++ b/src/operations/numeric/subtraction.cpp
@@ -6,7 +6,7 @@ using namespace nlohmann;
 
 namespace json_logic
 {
-    json JsonLogic::operation_numeric_subtraction(const json& values, const json& data)
+    json JsonLogic::operation_numeric_subtraction(const json& values, const json& data) const
     {
         if (values.empty() || values.size() > 2)
             throw JsonLogicException(

--- a/src/operations/string/cat.cpp
+++ b/src/operations/string/cat.cpp
@@ -25,7 +25,7 @@ namespace json_logic
 			if (!applied_value.is_string())
 				throw JsonLogicException(__FUNCTION__, "All arguments must be strings");
 
-			result += applied_value;
+			result += applied_value.get<std::string>();
 		}
 
 		return result;

--- a/src/operations/string/cat.cpp
+++ b/src/operations/string/cat.cpp
@@ -8,7 +8,7 @@ using namespace nlohmann;
 
 namespace json_logic
 {
-    json JsonLogic::operation_string_cat(const json& values, const json& data)
+    json JsonLogic::operation_string_cat(const json& values, const json& data) const
     {
 		if (values.size() < 2)
 			throw JsonLogicException(

--- a/src/operations/string/substr.cpp
+++ b/src/operations/string/substr.cpp
@@ -8,7 +8,7 @@ using namespace nlohmann;
 
 namespace json_logic
 {
-    json JsonLogic::operation_string_substr(const json& values, const json& data)
+    json JsonLogic::operation_string_substr(const json& values, const json& data) const
     {
 		if (values.size() < 2 || values.size() > 3)
 			throw JsonLogicException(


### PR DESCRIPTION
See each commit for details :)

Started using this library and noticed a few issues when including it in our build system:

1. implicit json casts -> compiler warning/error based on settings
2. constness: library is fully const but methods are not marked const meaning that you can't call `Apply` from a const context
3. cleaned up some legacy leftovers

I see it's been a while since this repo had any commits, but I thought I'd try my luck anyways. Let me know if these changes (or a subset) are desired :)